### PR TITLE
Persist products with localStorage

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -51,6 +51,4 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Initialize the app
     ProductManager.init();
-
-    // When using outside Claude.ai, add: ProductManager.loadFromLocalStorage();
 });

--- a/app/js/dataManagement.js
+++ b/app/js/dataManagement.js
@@ -11,8 +11,10 @@ const DataManager = (function() {
      * @returns {Object}
      */
     function getData() {
-        // const data = localStorage.getItem(storageKey);
-        // return data ? JSON.parse(data) : {};
+        const data = localStorage.getItem(storageKey);
+        if (data) {
+            memoryStore = JSON.parse(data);
+        }
         return memoryStore;
     }
 
@@ -23,7 +25,7 @@ const DataManager = (function() {
     function saveData(newData) {
         const updated = { ...memoryStore, ...newData };
         memoryStore = updated;
-        // localStorage.setItem(storageKey, JSON.stringify(updated));
+        localStorage.setItem(storageKey, JSON.stringify(updated));
     }
 
     /**
@@ -31,7 +33,7 @@ const DataManager = (function() {
      */
     function clearData() {
         memoryStore = {};
-        // localStorage.removeItem(storageKey);
+        localStorage.removeItem(storageKey);
     }
 
     return {

--- a/app/js/productManager.js
+++ b/app/js/productManager.js
@@ -11,11 +11,6 @@ const ProductManager = (function() {
     let isEditingGroup = false;
     let editingGroupIndex = -1;
 
-    // LOCAL STORAGE NOTE:
-    // localStorage is not supported in Claude.ai artifacts environment
-    // To add localStorage when using this code elsewhere, uncomment the functions below:
-
-    /*
     // Save products to localStorage
     function saveToLocalStorage() {
         localStorage.setItem('nyoki_products', JSON.stringify(products));
@@ -35,7 +30,6 @@ const ProductManager = (function() {
         }
         renderProducts();
     }
-    */
 
     // Group storage helpers
     function saveGroupsToStorage() {
@@ -465,7 +459,7 @@ const ProductManager = (function() {
 
                 renderProducts();
                 this.clearForm();
-                // When using outside Claude.ai, add: saveToLocalStorage();
+                saveToLocalStorage();
 
                 // Switch to view products after saving
                 if (!isEditing) {
@@ -489,7 +483,7 @@ const ProductManager = (function() {
             if (confirm('Are you sure you want to delete this product?')) {
                 products.splice(index, 1);
                 renderProducts();
-                // When using outside Claude.ai, add: saveToLocalStorage();
+                saveToLocalStorage();
             }
         },
 
@@ -678,6 +672,7 @@ const ProductManager = (function() {
                 populateGroupDropdowns();
                 renderProducts();
                 saveGroupsToStorage();
+                saveToLocalStorage();
             }
         },
 
@@ -689,6 +684,7 @@ const ProductManager = (function() {
 
         // Initialize groups
         init: function() {
+            loadFromLocalStorage();
             loadGroupsFromStorage();
             populateGroupDropdowns();
             renderGroups();
@@ -698,9 +694,6 @@ const ProductManager = (function() {
         renderProducts: function(filterGroupId) {
             renderProducts(filterGroupId);
         }
-
-        // Uncomment when using outside Claude.ai:
-        // loadFromLocalStorage: loadFromLocalStorage
     };
 })();
 


### PR DESCRIPTION
## Summary
- enable saving and loading of products from `localStorage`
- remove unused comments in the main app loader
- store data through `DataManager` in `localStorage`

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68744ac36598832f98ce4822609dec32