### PR TITLE
Update product card with collapsible costs

### DIFF
--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -117,6 +117,48 @@ body {
     box-shadow: 0 1px 2px rgba(0,0,0,0.1);
 }
 
+.product-photo {
+    width: 100%;
+    height: 150px;
+    object-fit: cover;
+    border-radius: var(--radius);
+    margin-bottom: 5px;
+}
+
+.product-title {
+    margin: 0 0 5px 0;
+    font-size: 1.1em;
+}
+
+.product-actions {
+    display: flex;
+    gap: 5px;
+    margin-bottom: 5px;
+}
+
+.product-actions button {
+    flex: 1;
+    padding: 5px;
+    background-color: var(--primary-color);
+    color: #fff;
+    border: none;
+    border-radius: var(--radius);
+    cursor: pointer;
+}
+
+.product-actions button:hover {
+    background-color: var(--secondary-color);
+}
+
+.cost-details {
+    margin-top: 5px;
+    font-size: 0.9em;
+}
+
+.hidden {
+    display: none;
+}
+
 .modal {
     display: none;
     position: fixed;

--- a/app/js/viewProducts.js
+++ b/app/js/viewProducts.js
@@ -1,16 +1,69 @@
 (function() {
     const productList = document.getElementById('productList');
 
+    /**
+     * Create a product card element with collapsible cost details.
+     * @param {Object} p Product data
+     * @returns {HTMLElement}
+     */
+    function createCard(p) {
+        const card = document.createElement('div');
+        card.className = 'product-card';
+
+        const img = document.createElement('img');
+        img.className = 'product-photo';
+        img.src = p.image || '../Nyoki-transparent-logo-lrg.png';
+        img.alt = p.name;
+        card.appendChild(img);
+
+        const title = document.createElement('h3');
+        title.className = 'product-title';
+        title.textContent = p.name;
+        card.appendChild(title);
+
+        const actions = document.createElement('div');
+        actions.className = 'product-actions';
+
+        const toggle = document.createElement('button');
+        toggle.textContent = 'Show Costs';
+        actions.appendChild(toggle);
+
+        const edit = document.createElement('button');
+        edit.textContent = 'Edit';
+        edit.addEventListener('click', () => alert('Edit feature not implemented')); // placeholder
+        actions.appendChild(edit);
+
+        const del = document.createElement('button');
+        del.textContent = 'Delete';
+        del.addEventListener('click', () => alert('Delete feature not implemented')); // placeholder
+        actions.appendChild(del);
+
+        card.appendChild(actions);
+
+        const cost = document.createElement('div');
+        cost.className = 'cost-details hidden';
+        cost.innerHTML = `
+            <p>Total Cost: £${p.totalCost.toFixed(2)}</p>
+            <p>Retail Price: £${p.retailPrice.toFixed(2)}</p>
+            <p>Profit: £${p.profit.toFixed(2)} (${p.margin}%)</p>
+            <div><strong>Materials:</strong></div>
+            <ul>
+                ${p.materials.map(m => `<li>${m.name}: £${m.cost.toFixed(2)}</li>`).join('')}
+            </ul>`;
+        card.appendChild(cost);
+
+        toggle.addEventListener('click', () => {
+            const hidden = cost.classList.toggle('hidden');
+            toggle.textContent = hidden ? 'Show Costs' : 'Hide Costs';
+        });
+
+        return card;
+    }
+
     function renderProducts() {
         productList.innerHTML = '';
         ProductModule.getProducts().forEach(p => {
-            const card = document.createElement('div');
-            card.className = 'product-card';
-            card.innerHTML = `<h3>${p.name}</h3>
-                <p>Total Cost: £${p.totalCost.toFixed(2)}</p>
-                <p>Retail Price: £${p.retailPrice.toFixed(2)}</p>
-                <p>Profit: £${p.profit.toFixed(2)} (${p.margin}%)</p>`;
-            productList.appendChild(card);
+            productList.appendChild(createCard(p));
         });
     }
 


### PR DESCRIPTION
## Summary
- show product photo, title and action buttons
- hide cost breakdown by default and allow toggling visibility
- add styles for new product card layout

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6874adae5a3c832f9b81abfa70d7ea67