### PR TITLE
Add VAT option to groups and update pricing logic

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -489,6 +489,11 @@
                         <input type="color" id="groupColor" value="#6b5b73">
                     </div>
 
+                    <div class="form-group">
+                        <label><input type="checkbox" id="groupHasVAT" onchange="document.getElementById('groupVATPercent').style.display=this.checked?'block':'none';"> Items in this group have VAT</label>
+                        <input type="number" id="groupVATPercent" placeholder="VAT %" step="0.01" style="display:none; margin-top:5px;">
+                    </div>
+
                     <button class="btn" onclick="saveGroup()">Save Group</button>
                 </div>
 

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -50,6 +50,7 @@ document.addEventListener('DOMContentLoaded', function() {
     inputs.forEach(id => {
         document.getElementById(id).addEventListener('input', ProductManager.updateBreakdown);
     });
+    document.getElementById('productGroup').addEventListener('change', ProductManager.updateBreakdown);
 
     // Initialize the app
     ProductManager.init();


### PR DESCRIPTION
## Summary
- add VAT fields to the Create New Group form
- allow editing VAT settings on groups
- include VAT in price calculations and breakdowns
- persist VAT info with products and groups
- update product group change handler

## Testing
- `node --check app/js/productManager.js`
- `node --check app/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_6874c2edd61c832f882bd4c254e12668