### PR TITLE
Align and style VAT checkboxes

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -144,6 +144,21 @@
             color: #5a4a4a;
         }
 
+        .checkbox-label {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .checkbox-label input[type="checkbox"] {
+            width: 18px;
+            height: 18px;
+            border: 2px solid #e8ddd4;
+            border-radius: 4px;
+            accent-color: #6b5b73;
+            cursor: pointer;
+        }
+
         input, textarea, select {
             width: 100%;
             padding: 12px;
@@ -490,7 +505,7 @@
                     </div>
 
                     <div class="form-group">
-                        <label><input type="checkbox" id="groupHasVAT" onchange="document.getElementById('groupVATPercent').style.display=this.checked?'block':'none';"> Items in this group have VAT</label>
+                        <label class="checkbox-label"><input type="checkbox" id="groupHasVAT" onchange="document.getElementById('groupVATPercent').style.display=this.checked?'block':'none';"> Items in this group have VAT</label>
                         <input type="number" id="groupVATPercent" placeholder="VAT %" step="0.01" style="display:none; margin-top:5px;">
                     </div>
 

--- a/app/js/productManager.js
+++ b/app/js/productManager.js
@@ -68,7 +68,7 @@ const ProductManager = (function() {
                                 <input type="text" id="editGroupName_${idx}" value="${g.name}" style="width:100%; margin-bottom:5px;">
                                 <textarea id="editGroupDescription_${idx}" rows="2" style="width:100%; margin-bottom:5px;">${g.description || ''}</textarea>
                                 <input type="color" id="editGroupColor_${idx}" value="${g.color}" style="margin-bottom:5px;">
-                                <label style="display:block; margin-bottom:5px;">
+                                <label class="checkbox-label" style="margin-bottom:5px;">
                                     <input type="checkbox" id="editGroupHasVAT_${idx}" ${g.hasVAT ? 'checked' : ''} onchange="document.getElementById('editGroupVATPercent_${idx}').style.display=this.checked?'block':'none';"> VAT Applicable
                                 </label>
                                 <input type="number" id="editGroupVATPercent_${idx}" value="${g.vatPercent}" step="0.01" style="width:100%; margin-bottom:5px; ${g.hasVAT ? '' : 'display:none;'}" placeholder="VAT %">


### PR DESCRIPTION
## Summary
- align VAT checkboxes with labels
- add larger custom styles for checkboxes

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6874dba8323c832f924c1cd0590e1d08