### PR TITLE
Add image selection option for products

### DIFF
--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -125,6 +125,13 @@ body {
     box-shadow: 0 1px 2px rgba(0,0,0,0.1);
 }
 
+.product-card img.product-image {
+    max-width: 100%;
+    height: auto;
+    border-radius: var(--radius);
+    margin-bottom: 10px;
+}
+
 .modal {
     display: none;
     position: fixed;

--- a/app/html/manage-products.html
+++ b/app/html/manage-products.html
@@ -54,6 +54,14 @@
                 <input type="number" id="packagingCost" step="0.01" min="0" value="0">
             </div>
             <div class="field">
+                <label for="imageFile">Product Image</label>
+                <input type="file" id="imageFile" accept="image/*">
+            </div>
+            <div class="field">
+                <label for="imageLink">Or CDN Image Link</label>
+                <input type="url" id="imageLink" placeholder="https://example.com/image.png">
+            </div>
+            <div class="field">
                 <label for="margin">Desired Margin (%)</label>
                 <input type="number" id="margin" step="1" min="0" value="20">
             </div>

--- a/app/index.html
+++ b/app/index.html
@@ -445,6 +445,10 @@
                             <label for="productImage" class="file-input-label">Choose Image</label>
                         </div>
                     </div>
+                    <div class="form-group">
+                        <label for="imageLink">Or CDN Image Link</label>
+                        <input type="url" id="imageLink" placeholder="https://example.com/image.png">
+                    </div>
 
                     <div class="form-group">
                         <label for="laborCost">Labor Cost (£)</label>

--- a/app/js/manageProducts.js
+++ b/app/js/manageProducts.js
@@ -42,6 +42,20 @@
         }));
     }
 
+    function getImageSrc() {
+        const fileInput = document.getElementById('imageFile');
+        const linkInput = document.getElementById('imageLink');
+        return new Promise(resolve => {
+            if (fileInput && fileInput.files && fileInput.files[0]) {
+                const reader = new FileReader();
+                reader.onload = () => resolve(reader.result);
+                reader.readAsDataURL(fileInput.files[0]);
+            } else {
+                resolve(linkInput ? linkInput.value.trim() : '');
+            }
+        });
+    }
+
     function clearForm() {
         form.reset();
         materialsList.innerHTML = '';
@@ -52,7 +66,8 @@
         ProductModule.getProducts().forEach(p => {
             const card = document.createElement('div');
             card.className = 'product-card';
-            card.innerHTML = `<h3>${p.name}</h3>
+            const imageHtml = p.image ? `<img src="${p.image}" alt="${p.name}" class="product-image">` : '';
+            card.innerHTML = `${imageHtml}<h3>${p.name}</h3>
                 <p>Total Cost: £${p.totalCost.toFixed(2)}</p>
                 <p>Retail Price: £${p.retailPrice.toFixed(2)}</p>
                 <p>Profit: £${p.profit.toFixed(2)} (${p.margin}%)</p>`;
@@ -62,10 +77,12 @@
 
     addMaterialBtn.addEventListener('click', createMaterialRow);
 
-    form.addEventListener('submit', event => {
+    form.addEventListener('submit', async event => {
         event.preventDefault();
+        const imageSrc = await getImageSrc();
         const product = {
             name: document.getElementById('productName').value.trim(),
+            image: imageSrc,
             materials: gatherMaterials(),
             laborCost: parseFloat(document.getElementById('laborCost').value) || 0,
             overheadCost: parseFloat(document.getElementById('overheadCost').value) || 0,

--- a/app/js/productManager.js
+++ b/app/js/productManager.js
@@ -609,7 +609,9 @@ const ProductManager = (function() {
 
         saveProduct: function() {
             const name = document.getElementById('productName').value.trim();
-            const imageFile = document.getElementById('productImage').files[0];
+            const fileInput = document.getElementById('productImage');
+            const imageFile = fileInput.files[0];
+            const imageLinkValue = document.getElementById('imageLink').value.trim();
 
             if (!name) {
                 Popup.alert('Please enter a product name');
@@ -713,6 +715,8 @@ const ProductManager = (function() {
                     saveProductData(e.target.result);
                 };
                 reader.readAsDataURL(imageFile);
+            } else if (imageLinkValue) {
+                saveProductData(imageLinkValue);
             } else {
                 saveProductData();
             }
@@ -741,6 +745,8 @@ const ProductManager = (function() {
             document.getElementById('postCost').value = product.postCost || 0;
             document.getElementById('packagingCost').value = product.packagingCost || 0;
             document.getElementById('retailPrice').value = product.retailPrice;
+            document.getElementById('productImage').value = '';
+            document.getElementById('imageLink').value = product.image && !product.image.startsWith('data:') ? product.image : '';
 
             // Calculate margin from current data including VAT
             const marginValue = product.baseMargin !== undefined
@@ -773,6 +779,7 @@ const ProductManager = (function() {
             document.getElementById('productGroup').value = '';
             renderMarketplaceOptions();
             document.getElementById('productImage').value = '';
+            document.getElementById('imageLink').value = '';
             document.getElementById('laborCost').value = '';
             document.getElementById('overheadCost').value = '';
             document.getElementById('postCost').value = '';

--- a/app/js/productModule.js
+++ b/app/js/productModule.js
@@ -7,6 +7,7 @@
     /** @typedef {Object} Product
      *  @property {number} id
      *  @property {string} name
+     *  @property {string} image
      *  @property {Material[]} materials
      *  @property {number} laborCost
      *  @property {number} overheadCost

--- a/app/js/viewProducts.js
+++ b/app/js/viewProducts.js
@@ -6,7 +6,8 @@
         ProductModule.getProducts().forEach(p => {
             const card = document.createElement('div');
             card.className = 'product-card';
-            card.innerHTML = `<h3>${p.name}</h3>
+            const imageHtml = p.image ? `<img src="${p.image}" alt="${p.name}" class="product-image">` : '';
+            card.innerHTML = `${imageHtml}<h3>${p.name}</h3>
                 <p>Total Cost: £${p.totalCost.toFixed(2)}</p>
                 <p>Retail Price: £${p.retailPrice.toFixed(2)}</p>
                 <p>Profit: £${p.profit.toFixed(2)} (${p.margin}%)</p>`;

--- a/docs/Technical-Requirements-Specification.md
+++ b/docs/Technical-Requirements-Specification.md
@@ -16,6 +16,7 @@ REQ-PROD-001: Users SHALL be able to create new products with the following attr
 
 Product name (required, text, max 255 characters)
 Product image (optional, image file, max 5MB, formats: JPG, PNG, GIF)
+CDN image link (optional, valid URL)
 Product group assignment (optional, dropdown selection)
 Labor cost (decimal, £0.00 format, max £999,999.99)
 Overhead cost (decimal, £0.00 format, max £999,999.99)


### PR DESCRIPTION
## Summary
- allow choosing local image files or CDN links when adding a product
- render product images in Manage and View pages
- document CDN image link capability
- style product images on product cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687607e1e244832fb445aed8b76ade1a