### PR TITLE
Add CDN link column to export

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 This tool calculates pricing for handcrafted products. You can manage products,
 materials and costs directly in the browser. On the **View Products** page,
 use the **Export CSV** button to download a CSV file containing each product's
-details, including materials, labor cost, overhead cost and marketplace
-information.
+details. The export now includes the CDN image link along with materials, labor
+cost, overhead cost and marketplace information.

--- a/app/js/productManager.js
+++ b/app/js/productManager.js
@@ -1057,6 +1057,7 @@ const ProductManager = (function() {
                 'ID',
                 'Name',
                 'Group',
+                'CDN Image Link',
                 'Retail Price',
                 'Total Cost',
                 'Profit',
@@ -1084,10 +1085,12 @@ const ProductManager = (function() {
                         const marginMp = mp.margin !== undefined ? mp.margin.toFixed(1) : '0.0';
                         return `${mpName}:${percent}%+${fixed}|fee:${fee}|profit:${profitMp}|margin:${marginMp}%`;
                     }).join('; ') : '';
+                const cdnLink = p.image && !p.image.startsWith('data:') ? p.image : '';
                 return [
                     p.id,
                     p.name,
                     groupName,
+                    cdnLink,
                     p.retailPrice.toFixed(2),
                     p.totalCost.toFixed(2),
                     profit.toFixed(2),


### PR DESCRIPTION
## Summary
- include CDN Image Link column in exported CSV
- note CDN links in README

## Testing
- `node --check app/js/productManager.js`

------
https://chatgpt.com/codex/tasks/task_e_68761344de44832fb0b955eb715b421e