### PR TITLE
Add discount analysis page

### DIFF
--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -211,6 +211,30 @@ body {
     cursor: pointer;
 }
 
+/* Discount analysis table */
+.discount-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 10px;
+}
+
+.discount-table th,
+.discount-table td {
+    border: 1px solid #ccc;
+    padding: 8px;
+    text-align: left;
+}
+
+.discount-table th {
+    background-color: #f0f0f0;
+}
+
+.disc10 { background-color: #e8f5e9; }
+.disc20 { background-color: #fff9e6; }
+.disc30 { background-color: #ffefe6; }
+.disc40 { background-color: #ffe6e6; }
+.disc50 { background-color: #f5e6ff; }
+
 @media (max-width: 600px) {
     .main-header {
         flex-direction: column;

--- a/app/html/discount-analysis.html
+++ b/app/html/discount-analysis.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>View Products - Nyoki</title>
+    <title>Discount Analysis - Nyoki</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Serif&display=swap" rel="stylesheet">
@@ -20,13 +20,33 @@
 
     <nav class="page-options">
         <a href="manage-products.html">Manage Products</a>
-        <a href="view-products.html" class="active">View Products</a>
-        <a href="discount-analysis.html">Discount Analysis</a>
+        <a href="view-products.html">View Products</a>
+        <a href="discount-analysis.html" class="active">Discount Analysis</a>
     </nav>
 
     <main class="content">
-        <h1>View Products</h1>
-        <div id="productList" class="product-grid"></div>
+        <h1>Discount Analysis</h1>
+        <div class="filter-bar">
+            <input type="text" id="searchInput" placeholder="Search products...">
+            <select id="categoryFilter" style="display:none;"></select>
+        </div>
+        <table class="discount-table">
+            <thead>
+                <tr>
+                    <th>Product</th>
+                    <th>Total Cost</th>
+                    <th>Retail Price</th>
+                    <th>Profit</th>
+                    <th>Margin</th>
+                    <th class="disc10">10% Off</th>
+                    <th class="disc20">20% Off</th>
+                    <th class="disc30">30% Off</th>
+                    <th class="disc40">40% Off</th>
+                    <th class="disc50">50% Off</th>
+                </tr>
+            </thead>
+            <tbody id="analysisBody"></tbody>
+        </table>
     </main>
 
     <div id="categoriesModal" class="modal">
@@ -48,7 +68,7 @@
     <script src="../js/popup.js"></script>
     <script src="../js/dataManagement.js"></script>
     <script src="../js/productModule.js"></script>
-    <script src="../js/viewProducts.js"></script>
+    <script src="../js/discountAnalysis.js"></script>
     <script src="../js/main.js"></script>
 </body>
 </html>

--- a/app/html/manage-products.html
+++ b/app/html/manage-products.html
@@ -21,6 +21,7 @@
     <nav class="page-options">
         <a href="manage-products.html" class="active">Manage Products</a>
         <a href="view-products.html">View Products</a>
+        <a href="discount-analysis.html">Discount Analysis</a>
     </nav>
 
     <main class="content">

--- a/app/index.html
+++ b/app/index.html
@@ -434,6 +434,7 @@
                 <button class="nav-btn" onclick="showView('view-products')">View Products</button>
                 <button class="nav-btn" onclick="showView('manage-groups')">Manage Groups</button>
                 <button class="nav-btn" onclick="showView('manage-marketplaces')">Manage Marketplaces</button>
+                <button class="nav-btn" onclick="location.href='html/discount-analysis.html'">Discount Analysis</button>
             </div>
         </div>
 

--- a/app/js/discountAnalysis.js
+++ b/app/js/discountAnalysis.js
@@ -1,0 +1,51 @@
+(function() {
+    const tbody = document.getElementById('analysisBody');
+    const searchInput = document.getElementById('searchInput');
+    const categoryFilter = document.getElementById('categoryFilter');
+
+    function loadCategories() {
+        const data = DataManager.getData();
+        if (data && Array.isArray(data.groups) && data.groups.length) {
+            categoryFilter.innerHTML = '<option value="">All Categories</option>' +
+                data.groups.map(g => `<option value="${g.id}">${g.name}</option>`).join('');
+            categoryFilter.style.display = 'inline-block';
+        }
+    }
+
+    function createDiscountCell(p, percent) {
+        const price = p.retailPrice * (1 - percent / 100);
+        const profit = price - p.totalCost;
+        const margin = (profit / p.totalCost) * 100;
+        return `<td class="disc${percent}">£${price.toFixed(2)}<br>` +
+               `£${profit.toFixed(2)}<br>${margin.toFixed(2)}%` +
+               `</td>`;
+    }
+
+    function render() {
+        const query = searchInput.value.toLowerCase();
+        const cat = categoryFilter.value;
+        tbody.innerHTML = '';
+        ProductModule.getProducts().forEach(p => {
+            if (query && !p.name.toLowerCase().includes(query)) return;
+            if (cat && p.groupId != cat) return;
+            const row = document.createElement('tr');
+            row.innerHTML = `
+                <td>${p.name}</td>
+                <td>£${p.totalCost.toFixed(2)}</td>
+                <td>£${p.retailPrice.toFixed(2)}</td>
+                <td>£${p.profit.toFixed(2)}</td>
+                <td>${p.margin.toFixed(2)}%</td>
+                ${[10,20,30,40,50].map(d => createDiscountCell(p,d)).join('')}
+            `;
+            tbody.appendChild(row);
+        });
+    }
+
+    searchInput.addEventListener('input', render);
+    categoryFilter.addEventListener('change', render);
+
+    document.addEventListener('DOMContentLoaded', () => {
+        loadCategories();
+        render();
+    });
+})();


### PR DESCRIPTION
## Summary
- create Discount Analysis page to evaluate price reductions
- implement client-side search/filter and discount calculations
- update navigation links to include Discount Analysis
- add discount-table and color classes for styling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a83ce63b0832fb6e6eac395a39da2