### PR TITLE
Add marketplace tabs to discount analysis

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -421,6 +421,28 @@
         .disc40 { background-color: #a2e0a0; }
         .disc50 { background-color: #89d889; }
 
+        .discount-tabs {
+            display: flex;
+            margin-bottom: 10px;
+            border-bottom: 1px solid #e8ddd4;
+        }
+
+        .discount-tab {
+            flex: 1;
+            padding: 10px;
+            background: none;
+            border: none;
+            font-weight: bold;
+            color: #6b5b73;
+            cursor: pointer;
+            transition: background 0.3s ease;
+        }
+
+        .discount-tab.active {
+            background: #6b5b73;
+            color: #fff;
+        }
+
         @media (max-width: 768px) {
             .main-content {
                 grid-template-columns: 1fr;
@@ -645,6 +667,7 @@
         <div id="discount-analysis-view" class="view-section">
             <div class="card">
                 <h2>Discount Analysis</h2>
+                <div id="discountTabs" class="discount-tabs"></div>
                 <div class="filter-bar" style="display:flex; gap:10px; margin-bottom:15px;">
                     <input type="text" id="analysisSearch" placeholder="Search products..." style="padding:8px; border:2px solid #e8ddd4; border-radius:6px;">
                     <select id="analysisCategory" style="padding:8px; border:2px solid #e8ddd4; border-radius:6px;">

--- a/app/js/discountAnalysis.js
+++ b/app/js/discountAnalysis.js
@@ -1,9 +1,14 @@
-(function() {
+const DiscountAnalysis = (function() {
+    let products = [];
+    let groups = [];
+    let marketplaces = [];
+    let currentMarketplaceId = '';
+
     function loadProducts() {
         const data = localStorage.getItem('nyoki_products');
         if (!data) return [];
-        const products = JSON.parse(data);
-        products.forEach(p => {
+        const list = JSON.parse(data);
+        list.forEach(p => {
             const basePrice = p.vatRate ? p.retailPrice / (1 + p.vatRate / 100) : p.retailPrice;
             if (p.baseProfit === undefined) {
                 p.baseProfit = basePrice - p.totalCost;
@@ -12,7 +17,7 @@
                 p.baseMargin = (p.baseProfit / p.totalCost) * 100;
             }
         });
-        return products;
+        return list;
     }
 
     function loadGroups() {
@@ -20,33 +25,69 @@
         return data ? JSON.parse(data) : [];
     }
 
-    function populateFilter(groups) {
+    function loadMarketplaces() {
+        const data = localStorage.getItem('nyoki_marketplaces');
+        return data ? JSON.parse(data) : [];
+    }
+
+    function populateFilter() {
         const select = document.getElementById('analysisCategory');
         if (!select) return;
         let options = '<option value="">All Categories</option>';
-        groups.forEach(g => {
-            options += `<option value="${g.id}">${g.name}</option>`;
-        });
+        groups.forEach(g => { options += `<option value="${g.id}">${g.name}</option>`; });
         select.innerHTML = options;
     }
 
-    function renderTable(products) {
+    function renderTabs() {
+        const container = document.getElementById('discountTabs');
+        if (!container) return;
+        marketplaces = loadMarketplaces();
+        let html = '<button class="discount-tab" data-id="">Base</button>';
+        marketplaces.forEach(mp => { html += `<button class="discount-tab" data-id="${mp.id}">${mp.name}</button>`; });
+        container.innerHTML = html;
+        const tabs = container.querySelectorAll('.discount-tab');
+        if (!tabs.length) return;
+        tabs.forEach(btn => {
+            btn.addEventListener('click', () => {
+                tabs.forEach(t => t.classList.remove('active'));
+                btn.classList.add('active');
+                currentMarketplaceId = btn.dataset.id || '';
+                renderTable();
+                filterRows();
+            });
+        });
+        tabs[0].classList.add('active');
+        currentMarketplaceId = tabs[0].dataset.id || '';
+    }
+
+    function renderTable() {
         const tbody = document.getElementById('discountTableBody');
-        tbody.innerHTML = products.map(p => {
+        if (!tbody) return;
+        const mp = marketplaces.find(m => String(m.id) === String(currentMarketplaceId));
+        const rows = products.map(p => {
+            const mpData = mp ? (p.marketplaces || []).find(m => m.id === mp.id) : null;
+            if (mp && !mpData) return '';
+            const profitDisplay = mp ? mpData.profit : p.baseProfit;
+            const marginDisplay = mp ? mpData.margin : p.baseMargin;
             const discountCols = [10,20,30,40,50].map(d => {
-                const price = p.retailPrice * (1 - d/100);
-                const profit = price - p.totalCost;
+                const price = p.retailPrice * (1 - d / 100);
+                let profit = price - p.totalCost;
+                if (mpData) {
+                    const fee = price * (mpData.chargePercent / 100) + mpData.chargeFixed;
+                    profit -= fee;
+                }
                 const margin = p.totalCost ? (profit / p.totalCost * 100) : 0;
                 return `<td class="disc${d}">£${price.toFixed(2)}<br>£${profit.toFixed(2)} (${margin.toFixed(1)}%)</td>`;
             }).join('');
-            return `<tr data-name="${p.name.toLowerCase()}" data-group="${p.groupId || ''}">
-                        <td>${p.name}</td>
-                        <td>£${p.retailPrice.toFixed(2)}</td>
-                        <td>£${p.baseProfit.toFixed(2)}</td>
-                        <td>${p.baseMargin.toFixed(1)}%</td>
-                        ${discountCols}
-                    </tr>`;
+            return `<tr data-name="${p.name.toLowerCase()}" data-group="${p.groupId || ''}">` +
+                   `<td>${p.name}</td>` +
+                   `<td>£${p.retailPrice.toFixed(2)}</td>` +
+                   `<td>£${profitDisplay.toFixed(2)}</td>` +
+                   `<td>${marginDisplay.toFixed(1)}%</td>` +
+                   discountCols +
+                   `</tr>`;
         }).join('');
+        tbody.innerHTML = rows;
     }
 
     function filterRows() {
@@ -61,14 +102,25 @@
         });
     }
 
-    document.addEventListener('DOMContentLoaded', function() {
-        const products = loadProducts();
-        const groups = loadGroups();
-        populateFilter(groups);
-        renderTable(products);
-
+    function init() {
+        products = loadProducts();
+        groups = loadGroups();
+        populateFilter();
+        renderTabs();
+        renderTable();
         document.getElementById('analysisSearch').addEventListener('input', filterRows);
         const groupSelect = document.getElementById('analysisCategory');
         if (groupSelect) groupSelect.addEventListener('change', filterRows);
-    });
+    }
+
+    return {
+        init,
+        renderTabs
+    };
 })();
+
+window.DiscountAnalysis = DiscountAnalysis;
+
+document.addEventListener('DOMContentLoaded', function() {
+    DiscountAnalysis.init();
+});

--- a/app/js/discountAnalysis.js
+++ b/app/js/discountAnalysis.js
@@ -43,7 +43,9 @@ const DiscountAnalysis = (function() {
         if (!container) return;
         marketplaces = loadMarketplaces();
         let html = '<button class="discount-tab" data-id="">Base</button>';
-        marketplaces.forEach(mp => { html += `<button class="discount-tab" data-id="${mp.id}">${mp.name}</button>`; });
+        marketplaces.forEach(mp => {
+            html += `<button class="discount-tab" data-id="${mp.id}">${mp.name}</button>`;
+        });
         container.innerHTML = html;
         const tabs = container.querySelectorAll('.discount-tab');
         if (!tabs.length) return;
@@ -58,6 +60,8 @@ const DiscountAnalysis = (function() {
         });
         tabs[0].classList.add('active');
         currentMarketplaceId = tabs[0].dataset.id || '';
+        renderTable();
+        filterRows();
     }
 
     function renderTable() {
@@ -102,6 +106,14 @@ const DiscountAnalysis = (function() {
         });
     }
 
+    function refresh() {
+        products = loadProducts();
+        groups = loadGroups();
+        populateFilter();
+        renderTabs();
+        filterRows();
+    }
+
     function init() {
         products = loadProducts();
         groups = loadGroups();
@@ -115,7 +127,9 @@ const DiscountAnalysis = (function() {
 
     return {
         init,
-        renderTabs
+        renderTabs,
+        refresh,
+        renderTable
     };
 })();
 

--- a/app/js/productManager.js
+++ b/app/js/productManager.js
@@ -752,6 +752,9 @@ const ProductManager = (function() {
                 renderProducts();
                 this.clearForm();
                 saveToLocalStorage();
+                if (window.DiscountAnalysis) {
+                    DiscountAnalysis.refresh();
+                }
 
                 // Switch to view products after saving
                 if (!isEditing) {
@@ -778,6 +781,9 @@ const ProductManager = (function() {
                 products.splice(index, 1);
                 renderProducts();
                 saveToLocalStorage();
+                if (window.DiscountAnalysis) {
+                    DiscountAnalysis.refresh();
+                }
             });
         },
 
@@ -1024,6 +1030,9 @@ const ProductManager = (function() {
             }
             saveMarketplacesToStorage();
             this.clearMarketplaceForm();
+            if (window.DiscountAnalysis) {
+                DiscountAnalysis.refresh();
+            }
         },
 
         editMarketplace: function(index) {
@@ -1057,6 +1066,9 @@ const ProductManager = (function() {
                 DiscountAnalysis.renderTabs();
             }
             saveMarketplacesToStorage();
+            if (window.DiscountAnalysis) {
+                DiscountAnalysis.refresh();
+            }
         },
 
         cancelMarketplaceEdit: function() {
@@ -1097,6 +1109,9 @@ const ProductManager = (function() {
             renderProducts();
             saveMarketplacesToStorage();
             saveToLocalStorage();
+            if (window.DiscountAnalysis) {
+                DiscountAnalysis.refresh();
+            }
         },
 
         clearMarketplaceForm: function() {

--- a/app/js/productManager.js
+++ b/app/js/productManager.js
@@ -1019,6 +1019,9 @@ const ProductManager = (function() {
 
             renderMarketplaces();
             renderMarketplaceOptions();
+            if (window.DiscountAnalysis) {
+                DiscountAnalysis.renderTabs();
+            }
             saveMarketplacesToStorage();
             this.clearMarketplaceForm();
         },
@@ -1050,6 +1053,9 @@ const ProductManager = (function() {
             editingMarketplaceIndex = -1;
             renderMarketplaces();
             renderMarketplaceOptions();
+            if (window.DiscountAnalysis) {
+                DiscountAnalysis.renderTabs();
+            }
             saveMarketplacesToStorage();
         },
 
@@ -1085,6 +1091,9 @@ const ProductManager = (function() {
             marketplaces.splice(index, 1);
             renderMarketplaces();
             renderMarketplaceOptions();
+            if (window.DiscountAnalysis) {
+                DiscountAnalysis.renderTabs();
+            }
             renderProducts();
             saveMarketplacesToStorage();
             saveToLocalStorage();


### PR DESCRIPTION
## Summary
- include a tab bar to switch discount analysis per marketplace
- style tabs in `index.html`
- build DiscountAnalysis module to render per-marketplace tables
- refresh discount analysis tabs when marketplaces are changed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a99e66508832f9240b3a005e5f401