### PR TITLE
Add stock quantity feature

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -542,6 +542,11 @@
                         <input type="number" id="packagingCost" step="0.01" placeholder="0.00">
                     </div>
 
+                    <div class="form-group">
+                        <label for="stockCount">Stock Quantity</label>
+                        <input type="number" id="stockCount" step="1" min="0" placeholder="0">
+                    </div>
+
                     <h3 style="color: #6b5b73; margin: 20px 0 15px;">Materials</h3>
                     <div class="form-group">
                         <label for="materialName">Material Name</label>

--- a/app/js/productManager.js
+++ b/app/js/productManager.js
@@ -61,6 +61,10 @@ const ProductManager = (function() {
                     });
                 }
 
+                if (p.stockCount === undefined) {
+                    p.stockCount = 0;
+                }
+
                 delete p.marketplaceId;
                 delete p.marketplaceFee;
                 delete p.profit;
@@ -493,6 +497,10 @@ const ProductManager = (function() {
                                     <span>Total Cost:</span>
                                     <span>£${product.totalCost.toFixed(2)}</span>
                                 </div>
+                                <div class="profit-row">
+                                    <span>Stock:</span>
+                                    <span>${product.stockCount || 0}</span>
+                                </div>
                                 ${product.vatRate ? `<div class="profit-row"><span>VAT (${product.vatRate}%):</span><span>£${vatAmount.toFixed(2)}</span></div>` : ''}
                                 <div class="profit-row">
                                     <span>Retail Price:</span>
@@ -533,6 +541,10 @@ const ProductManager = (function() {
                                 <div class="profit-row total">
                                     <span>Total Cost:</span>
                                     <span>£${product.totalCost.toFixed(2)}</span>
+                                </div>
+                                <div class="profit-row">
+                                    <span>Stock:</span>
+                                    <span>${product.stockCount || 0}</span>
                                 </div>
                                 ${product.vatRate ? `<div class="profit-row"><span>VAT (${product.vatRate}%):</span><span>£${vatAmount.toFixed(2)}</span></div>` : ''}
                                <div class="profit-row">
@@ -705,6 +717,7 @@ const ProductManager = (function() {
                 overheadCost: costs.overheadCost,
                 postCost: costs.postCost,
                 packagingCost: costs.packagingCost,
+                stockCount: parseInt(document.getElementById('stockCount').value) || 0,
                 totalCost: costs.totalCost,
                 retailPrice: finalRetailPrice,
                 vatRate,
@@ -785,6 +798,7 @@ const ProductManager = (function() {
             document.getElementById('overheadCost').value = product.overheadCost;
             document.getElementById('postCost').value = product.postCost || 0;
             document.getElementById('packagingCost').value = product.packagingCost || 0;
+            document.getElementById('stockCount').value = product.stockCount || 0;
             document.getElementById('retailPrice').value = product.retailPrice;
             document.getElementById('productImage').value = '';
             document.getElementById('imageLink').value = product.image && !product.image.startsWith('data:') ? product.image : '';
@@ -825,6 +839,7 @@ const ProductManager = (function() {
             document.getElementById('overheadCost').value = '';
             document.getElementById('postCost').value = '';
             document.getElementById('packagingCost').value = '';
+            document.getElementById('stockCount').value = '';
             document.getElementById('marginPercent').value = '';
             document.getElementById('retailPrice').value = '';
             materials = [];


### PR DESCRIPTION
## Summary
- allow entering a Stock Quantity when creating or editing a product
- save stock data in ProductManager and display it on product cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b4e55b13c832f87afdeac91c0f21d