### PR TITLE
Add product view popup to discount analysis

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -378,6 +378,7 @@
             align-items: center;
             justify-content: center;
             background: rgba(0,0,0,0.5);
+            overflow-y: auto;
             z-index: 3000;
         }
 

--- a/app/index.html
+++ b/app/index.html
@@ -389,6 +389,8 @@
             width: 100%;
             box-shadow: 0 4px 15px rgba(0,0,0,0.2);
             text-align: center;
+            max-height: 80vh;
+            overflow-y: auto;
         }
 
         .popup-buttons {

--- a/app/index.html
+++ b/app/index.html
@@ -386,7 +386,7 @@
             background: white;
             padding: 20px;
             border-radius: 12px;
-            max-width: 400px;
+            max-width: 600px;
             width: 100%;
             box-shadow: 0 4px 15px rgba(0,0,0,0.2);
             text-align: center;
@@ -399,6 +399,22 @@
             display: flex;
             gap: 10px;
             justify-content: center;
+        }
+
+        .popup-columns {
+            display: flex;
+            gap: 20px;
+            justify-content: center;
+        }
+
+        .popup-col {
+            flex: 1;
+        }
+
+        @media (max-width: 600px) {
+            .popup-columns {
+                flex-direction: column;
+            }
         }
 
         .discount-table {

--- a/app/index.html
+++ b/app/index.html
@@ -690,6 +690,7 @@
                     <thead>
                         <tr>
                             <th>Product</th>
+                            <th>View</th>
                             <th>Retail Price</th>
                             <th>Profit</th>
                             <th>Margin %</th>

--- a/app/js/discountAnalysis.js
+++ b/app/js/discountAnalysis.js
@@ -114,7 +114,7 @@ const DiscountAnalysis = (function() {
                    `<div class="profit-row total"><span>${name} Profit:</span><span>£${mp.profit.toFixed(2)} (${mp.margin.toFixed(1)}%)</span></div>`;
         }).join('') : '';
 
-        const mpSection = mpRows ? `<div class="profit-analysis" style="margin-top:15px;">${mpRows}</div>` : '';
+        const mpSection = mpRows ? `<div class="profit-analysis">${mpRows}</div>` : '';
 
         const materialsListHtml = product.materials.map(m => `<div style="font-size:0.9em; color:#666;">• ${m.name}: £${m.cost.toFixed(2)}</div>`).join('');
 
@@ -122,9 +122,7 @@ const DiscountAnalysis = (function() {
         const baseProfit = product.baseProfit !== undefined ? product.baseProfit : ((product.retailPrice / (1 + (product.vatRate || 0) / 100)) - product.totalCost);
         const baseMargin = product.baseMargin !== undefined ? product.baseMargin : (baseProfit / product.totalCost * 100);
 
-        return `
-            <h3 style="margin-bottom:10px;">${product.name}</h3>
-            ${product.image ? `<div style="margin-bottom:10px;"><img src="${product.image}" alt="${product.name}" style="max-width:100%; max-height:200px; object-fit:contain; border-radius:8px;"></div>` : ''}
+        const costSection = `
             <div class="profit-analysis">
                 <div class="profit-row total"><span>Total Cost:</span><span>£${product.totalCost.toFixed(2)}</span></div>
                 <div class="profit-row"><span>Stock:</span><span>${product.stockCount || 0}</span></div>
@@ -132,12 +130,21 @@ const DiscountAnalysis = (function() {
                 <div class="profit-row"><span>Retail Price:</span><span>£${product.retailPrice.toFixed(2)}</span></div>
                 <div class="profit-row total"><span>Profit:</span><span>£${baseProfit.toFixed(2)}</span></div>
                 <div class="profit-row total"><span>Margin:</span><span>${baseMargin.toFixed(1)}%</span></div>
-            </div>
-            <div style="margin-top:15px;">
-                <div><strong>Materials:</strong></div>
-                ${materialsListHtml}
-            </div>
-            ${mpSection}`;
+                <div style="margin-top:15px;">
+                    <div><strong>Materials:</strong></div>
+                    ${materialsListHtml}
+                </div>
+            </div>`;
+
+        const mpColumn = mpSection ? `<div class="popup-col">${mpSection}</div>` : '';
+
+        return `
+            <h3 style="margin-bottom:10px;">${product.name}</h3>
+            ${product.image ? `<div style="margin-bottom:10px;"><img src="${product.image}" alt="${product.name}" style="max-width:100%; max-height:200px; object-fit:contain; border-radius:8px;"></div>` : ''}
+            <div class="popup-columns">
+                <div class="popup-col">${costSection}</div>
+                ${mpColumn}
+            </div>`;
     }
 
     function viewProduct(index) {

--- a/app/js/discountAnalysis.js
+++ b/app/js/discountAnalysis.js
@@ -124,7 +124,7 @@ const DiscountAnalysis = (function() {
 
         return `
             <h3 style="margin-bottom:10px;">${product.name}</h3>
-            ${product.image ? `<div style="margin-bottom:10px;"><img src="${product.image}" alt="${product.name}" style="max-width:100%; border-radius:8px;"></div>` : ''}
+            ${product.image ? `<div style="margin-bottom:10px;"><img src="${product.image}" alt="${product.name}" style="max-width:100%; max-height:200px; object-fit:contain; border-radius:8px;"></div>` : ''}
             <div class="profit-analysis">
                 <div class="profit-row total"><span>Total Cost:</span><span>£${product.totalCost.toFixed(2)}</span></div>
                 <div class="profit-row"><span>Stock:</span><span>${product.stockCount || 0}</span></div>

--- a/app/js/popup.js
+++ b/app/js/popup.js
@@ -46,12 +46,44 @@ const Popup = (function() {
         document.body.appendChild(overlay);
     }
 
+    function customPopup(html, options = {}) {
+        const overlay = document.createElement('div');
+        overlay.className = 'popup-overlay';
+
+        const box = document.createElement('div');
+        box.className = 'popup';
+
+        const content = document.createElement('div');
+        content.innerHTML = html;
+        box.appendChild(content);
+
+        const buttons = document.createElement('div');
+        buttons.className = 'popup-buttons';
+
+        const close = document.createElement('button');
+        close.className = 'btn';
+        close.textContent = options.closeText || 'Close';
+        close.addEventListener('click', () => {
+            document.body.removeChild(overlay);
+            if (options.onClose) options.onClose();
+        });
+
+        buttons.appendChild(close);
+        box.appendChild(buttons);
+
+        overlay.appendChild(box);
+        document.body.appendChild(overlay);
+    }
+
     return {
         alert(message) {
             create(message);
         },
         confirm(message, onConfirm, onCancel) {
             create(message, { type: 'confirm', onConfirm, onCancel });
+        },
+        custom(html, options) {
+            customPopup(html, options);
         }
     };
 })();

--- a/app/js/popup.js
+++ b/app/js/popup.js
@@ -3,6 +3,17 @@ const Popup = (function() {
         const overlay = document.createElement('div');
         overlay.className = 'popup-overlay';
 
+        overlay.addEventListener('click', (e) => {
+            if (e.target === overlay) {
+                document.body.removeChild(overlay);
+                if (options.type === 'confirm') {
+                    if (options.onCancel) options.onCancel();
+                } else if (options.onClose) {
+                    options.onClose();
+                }
+            }
+        });
+
         const box = document.createElement('div');
         box.className = 'popup';
 
@@ -49,6 +60,13 @@ const Popup = (function() {
     function customPopup(html, options = {}) {
         const overlay = document.createElement('div');
         overlay.className = 'popup-overlay';
+
+        overlay.addEventListener('click', (e) => {
+            if (e.target === overlay) {
+                document.body.removeChild(overlay);
+                if (options.onClose) options.onClose();
+            }
+        });
 
         const box = document.createElement('div');
         box.className = 'popup';


### PR DESCRIPTION
## Summary
- add View column to Discount Analysis table
- allow Discount Analysis to open a popup showing product details and image
- extend Popup module with a `custom` popup helper

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687b51aacbdc832fbe25401e87fb69e6