### PR TITLE
Make discount analysis tabs sticky

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -449,6 +449,10 @@
             display: flex;
             margin-bottom: 10px;
             border-bottom: 1px solid #e8ddd4;
+            position: sticky;
+            top: 0;
+            background: #fff;
+            z-index: 851;
         }
 
         .discount-tab {
@@ -465,6 +469,10 @@
         .discount-tab.active {
             background: #6b5b73;
             color: #fff;
+        }
+
+        #discount-analysis-view .filter-bar {
+            top: 40px;
         }
 
         @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- make the discount analysis tabs stick to the top when scrolling
- shift the filter bar down so it doesn't overlap the sticky tabs

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687b5ff32624832f98f74796a77cd1fe