### PR TITLE
Ensure add product form picks up global post costs

### DIFF
--- a/app/js/postPackaging.js
+++ b/app/js/postPackaging.js
@@ -33,11 +33,19 @@ const PostPackaging = (function() {
         }
     }
 
+    function updateProductForm() {
+        if (window.ProductManager && ProductManager.setPostPackagingInputs &&
+            ProductManager.isEditingProduct && !ProductManager.isEditingProduct()) {
+            ProductManager.setPostPackagingInputs(postCost, packagingCost);
+        }
+    }
+
     return {
         init: function() {
             loadFromStorage();
             updateInputs();
             applyToProducts();
+            updateProductForm();
         },
         save: function() {
             const postInput = parseFloat(document.getElementById('globalPostCost').value) || 0;
@@ -51,6 +59,7 @@ const PostPackaging = (function() {
             saveToStorage();
             applyToProducts();
             updateInputs();
+            updateProductForm();
         },
         getValues: function() {
             return { postCost, packagingCost };

--- a/app/js/productManager.js
+++ b/app/js/productManager.js
@@ -1319,6 +1319,20 @@ const ProductManager = (function() {
             return products.slice();
         },
 
+        isEditingProduct: function() {
+            return isEditing;
+        },
+
+        setPostPackagingInputs: function(post, pack) {
+            if (!isEditing) {
+                const postInput = document.getElementById('postCost');
+                const packInput = document.getElementById('packagingCost');
+                if (postInput) postInput.value = post;
+                if (packInput) packInput.value = pack;
+                updateCostBreakdown();
+            }
+        },
+
         applyPostPackagingCosts: function(post, pack) {
             products.forEach(p => {
                 p.postCost = post;


### PR DESCRIPTION
## Summary
- expose `isEditingProduct` and `setPostPackagingInputs` helpers
- update Post & Packaging logic to sync values with the add-product form

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_687b8fb4098c832f9574b38ecf5bda56