### PR TITLE
Add thumbnail and tooltip to discount analysis

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -430,6 +430,39 @@
             text-align: center;
         }
 
+        .discount-table .product-cell {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .discount-table .table-thumb {
+            width: 40px;
+            height: 40px;
+            object-fit: cover;
+            border-radius: 6px;
+        }
+
+        .discount-table .product-name[data-tooltip] {
+            position: relative;
+            cursor: help;
+        }
+
+        .discount-table .product-name[data-tooltip]:hover::after {
+            content: attr(data-tooltip);
+            position: absolute;
+            left: 0;
+            top: 100%;
+            margin-top: 4px;
+            background: #6b5b73;
+            color: #fff;
+            padding: 4px 8px;
+            border-radius: 6px;
+            white-space: nowrap;
+            box-shadow: 0 4px 15px rgba(0,0,0,0.08);
+            z-index: 10;
+        }
+
         .discount-table tbody tr:hover td {
             background-color: #f9f7f4;
         }

--- a/app/js/discountAnalysis.js
+++ b/app/js/discountAnalysis.js
@@ -88,8 +88,11 @@ const DiscountAnalysis = (function() {
                 const margin = p.totalCost ? (profit / p.totalCost * 100) : 0;
                 return `<td class="disc${d}">£${discountedRetailPrice.toFixed(2)}<br>£${profit.toFixed(2)} (${margin.toFixed(1)}%)</td>`;
             }).join('');
+            const truncatedName = p.name.length > 50 ? p.name.slice(0, 50) + '…' : p.name;
+            const thumb = p.image ? `<img src="${p.image}" alt="${p.name}" class="table-thumb">` : '';
+            const nameCell = `<td class="product-cell"><span>${thumb}</span><span class="product-name" data-tooltip="${p.name}">${truncatedName}</span></td>`;
             return `<tr data-index="${idx}" data-name="${p.name.toLowerCase()}" data-category="${p.categoryId || ''}">` +
-                   `<td>${p.name}</td>` +
+                   nameCell +
                    `<td><button class="btn btn-secondary btn-view" data-index="${idx}">View</button></td>` +
                    `<td>£${p.retailPrice.toFixed(2)}</td>` +
                    `<td>£${profitDisplay.toFixed(2)}</td>` +


### PR DESCRIPTION
## Summary
- add styling for thumbnail and tooltip in Discount Analysis
- render thumbnail and truncated product name with tooltip

## Testing
- `node --check app/js/discountAnalysis.js`
- `node --check app/js/productManager.js`
- `node --check app/js/popup.js`
- `node --check app/js/app.js`
- `node --check app/js/postPackaging.js`


------
https://chatgpt.com/codex/tasks/task_e_687be96a5708832faf9501421e967e96