### PR TITLE
Fix Safari thumbnail sizing

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -460,10 +460,12 @@
         }
 
         .discount-table .table-thumb {
-            width: 90%;
-            height: 90%;
+            width: 40px;
+            height: 40px;
             object-fit: cover;
             border-radius: 6px;
+            display: block;
+            margin: 0 auto;
         }
 
         .discount-table .thumb-cell {


### PR DESCRIPTION
## Summary
- adjust discount analysis thumbnail CSS so Safari renders correctly

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687bff6803e0832f9e09cbb5257a38f2