### PR TITLE
Fix sticky nav

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -31,6 +31,9 @@
             box-shadow: 0 4px 15px rgba(0,0,0,0.08);
             margin-bottom: 30px;
             overflow: hidden;
+            position: sticky;
+            top: 0;
+            z-index: 900;
         }
 
         .nav-buttons {
@@ -378,7 +381,7 @@
 
         .filter-bar {
             position: sticky;
-            top: 0px;
+            top: 60px;
             background: #fff;
             z-index: 850;
             padding: 10px 0;
@@ -519,7 +522,7 @@
             margin-bottom: 10px;
             border-bottom: 1px solid #e8ddd4;
             position: sticky;
-            top: 0;
+            top: 60px;
             background: #fff;
             z-index: 851;
         }
@@ -570,7 +573,7 @@
         }
 
         #discount-analysis-view .filter-bar {
-            top: 40px;
+            top: 100px;
         }
 
         @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- make nav menu sticky at top of viewport
- offset discount tabs and filter bars so they don't overlap

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687caa307d5c832f9359e227156decd7