### PR TITLE
Add stock level border colors

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -568,6 +568,18 @@
             cursor: pointer;
         }
 
+        .stock-input.stock-zero {
+            border: 3px solid #c17b7b !important;
+        }
+
+        .stock-input.stock-low {
+            border: 3px solid #d6955b !important;
+        }
+
+        .stock-input.stock-ok {
+            border: 3px solid #7ba05b !important;
+        }
+
         .save-actions {
             text-align: right;
         }

--- a/app/js/manageStock.js
+++ b/app/js/manageStock.js
@@ -14,6 +14,18 @@ const ManageStock = (function() {
         products = data ? JSON.parse(data) : [];
     }
 
+    function getBorderClass(qty) {
+        if (qty === 0) return 'stock-zero';
+        if (qty < 5) return 'stock-low';
+        return 'stock-ok';
+    }
+
+    function applyInputClass(input) {
+        const val = parseInt(input.value, 10) || 0;
+        input.classList.remove('stock-zero', 'stock-low', 'stock-ok');
+        input.classList.add(getBorderClass(val));
+    }
+
     function renderTable() {
         loadProducts();
         const tbody = document.getElementById('manageStockBody');
@@ -36,9 +48,14 @@ const ManageStock = (function() {
         const rows = filtered.map(p => {
             const img = p.image ? `<img src="${p.image}" alt="${p.name}" class="stock-thumb">` : '';
             const qty = p.stockCount !== undefined ? p.stockCount : 0;
-            return `<tr data-category="${p.categoryId || ''}" data-name="${p.name.toLowerCase()}"><td>${img}</td><td>${p.name}</td><td><input type="number" class="stock-input" data-id="${p.id}" value="${qty}" style="width:80px;"></td></tr>`;
+            const cls = getBorderClass(qty);
+            return `<tr data-category="${p.categoryId || ''}" data-name="${p.name.toLowerCase()}"><td>${img}</td><td>${p.name}</td><td><input type="number" class="stock-input ${cls}" data-id="${p.id}" value="${qty}" style="width:80px;"></td></tr>`;
         }).join('');
         tbody.innerHTML = rows;
+
+        tbody.querySelectorAll('.stock-input').forEach(inp => {
+            inp.addEventListener('input', () => applyInputClass(inp));
+        });
     }
 
     function showImage(src, name) {


### PR DESCRIPTION
## Summary
- highlight Manage Stock input borders based on quantity
- add CSS classes for stock quantity border colours

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687cc9b4029c832faf09d0106bcc4ed9