### PR TITLE
Move Post & Packaging into settings popup

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -645,7 +645,6 @@
                 <button class="nav-btn" onclick="showView('manage-stock')">Manage Stock</button>
                 <button class="nav-btn" onclick="showView('manage-categories')">Manage Categories</button>
                 <button class="nav-btn" onclick="showView('manage-marketplaces')">Manage Marketplaces</button>
-                <button class="nav-btn" onclick="showView('post-packaging')">Post &amp; Packaging</button>
             </div>
         </div>
 
@@ -862,23 +861,6 @@
             </div>
         </div>
 
-        <!-- Post & Packaging View -->
-        <div id="post-packaging-view" class="view-section">
-            <div class="main-content">
-                <div class="card">
-                    <h2>Global Post &amp; Packaging</h2>
-                    <div class="form-group">
-                        <label for="globalPostCost">Post &amp; Shipping Cost (£)</label>
-                        <input type="number" id="globalPostCost" step="0.01" placeholder="0.00">
-                    </div>
-                    <div class="form-group">
-                        <label for="globalPackagingCost">Packaging Cost (£)</label>
-                        <input type="number" id="globalPackagingCost" step="0.01" placeholder="0.00">
-                    </div>
-                    <button class="btn" onclick="savePostPackaging()">Save</button>
-                </div>
-            </div>
-        </div>
 
         <!-- Discount Analysis View -->
         <div id="discount-analysis-view" class="view-section">

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -16,7 +16,40 @@ function saveMarketplace() {
 }
 
 function openSettings() {
-    Popup.custom('<h2 style="text-align:left;">Settings</h2>');
+    const html = `
+        <h2 style="text-align:left;">Settings</h2>
+        <div style="display:flex; flex-direction:column; gap:10px; margin-top:10px;">
+            <button class="btn" onclick="openThemeSettings()">Set Colour Themes</button>
+            <button class="btn" onclick="openPostPackagingSettings()">Post &amp; Packaging</button>
+        </div>`;
+    Popup.custom(html, { closeText: 'Close' });
+}
+
+function openThemeSettings() {
+    const html = `<h2 style="text-align:left;">Set Colour Themes</h2><p>Coming soon...</p>`;
+    Popup.custom(html, { closeText: 'Close' });
+}
+
+function openPostPackagingSettings() {
+    const html = `
+        <h2 style="text-align:left;">Post &amp; Packaging</h2>
+        <div class="main-content">
+            <div class="card">
+                <div class="form-group">
+                    <label for="globalPostCost">Post &amp; Shipping Cost (£)</label>
+                    <input type="number" id="globalPostCost" step="0.01" placeholder="0.00">
+                </div>
+                <div class="form-group">
+                    <label for="globalPackagingCost">Packaging Cost (£)</label>
+                    <input type="number" id="globalPackagingCost" step="0.01" placeholder="0.00">
+                </div>
+                <button class="btn" onclick="savePostPackaging()">Save</button>
+            </div>
+        </div>`;
+    Popup.custom(html, { closeText: 'Close' });
+    if (window.PostPackaging) {
+        PostPackaging.init();
+    }
 }
 
 function exportProducts() {
@@ -109,9 +142,6 @@ function showView(viewName) {
     } else if (viewName === 'manage-marketplaces') {
         document.getElementById('manage-marketplaces-view').classList.add('active');
         document.querySelectorAll('.nav-btn')[5].classList.add('active');
-    } else if (viewName === 'post-packaging') {
-        document.getElementById('post-packaging-view').classList.add('active');
-        document.querySelectorAll('.nav-btn')[6].classList.add('active');
     }
 }
 


### PR DESCRIPTION
## Summary
- add menu options for colour themes and Post & Packaging under settings
- show Post & Packaging form in a popup instead of a separate tab
- remove Post & Packaging tab and view from main page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687ce10a6f9c832fbc9829efe136134e