### PR TITLE
Add discount theme color setting

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -934,6 +934,7 @@
     </div>
 
     <script src="js/popup.js"></script>
+    <script src="js/themeManager.js"></script>
     <script src="js/productManager.js"></script>
     <script src="js/discountAnalysis.js"></script>
     <script src="js/postPackaging.js"></script>

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -26,21 +26,33 @@ function openSettings() {
 }
 
 function openThemeSettings() {
-    const current = ThemeManager ? ThemeManager.getDiscountColor() : '#ff4d4d';
+    const mps = ProductManager.getMarketplaces ? ProductManager.getMarketplaces() : [];
+    const current = ThemeManager ? ThemeManager.getDiscountColor('') : '#ff4d4d';
+    const options = ['<option value="">Base</option>'].concat(mps.map(mp => `<option value="${mp.id}">${mp.name}</option>`)).join('');
     const html = `
         <h2 style="text-align:left;">Set Colour Themes</h2>
+        <div class="form-group" style="margin-bottom:10px;">
+            <label for="themeMarketplaceSelect">Marketplace</label>
+            <select id="themeMarketplaceSelect">${options}</select>
+        </div>
         <div class="form-group" style="margin-bottom:15px;">
             <label for="discountBaseColour">Discount Base Colour</label>
             <input type="color" id="discountBaseColour" value="${current}">
         </div>
         <button class="btn" onclick="saveThemeSettings()">Save</button>`;
     Popup.custom(html, { closeText: 'Close' });
+    const select = document.getElementById('themeMarketplaceSelect');
+    select.addEventListener('change', () => {
+        const color = ThemeManager.getDiscountColor(select.value);
+        document.getElementById('discountBaseColour').value = color;
+    });
 }
 
 function saveThemeSettings() {
     const inp = document.getElementById('discountBaseColour');
-    if (inp && ThemeManager && inp.value) {
-        ThemeManager.setDiscountColor(inp.value);
+    const select = document.getElementById('themeMarketplaceSelect');
+    if (inp && select && ThemeManager && inp.value) {
+        ThemeManager.setDiscountColor(inp.value, select.value);
     }
 }
 

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -26,8 +26,22 @@ function openSettings() {
 }
 
 function openThemeSettings() {
-    const html = `<h2 style="text-align:left;">Set Colour Themes</h2><p>Coming soon...</p>`;
+    const current = ThemeManager ? ThemeManager.getDiscountColor() : '#ff4d4d';
+    const html = `
+        <h2 style="text-align:left;">Set Colour Themes</h2>
+        <div class="form-group" style="margin-bottom:15px;">
+            <label for="discountBaseColour">Discount Base Colour</label>
+            <input type="color" id="discountBaseColour" value="${current}">
+        </div>
+        <button class="btn" onclick="saveThemeSettings()">Save</button>`;
     Popup.custom(html, { closeText: 'Close' });
+}
+
+function saveThemeSettings() {
+    const inp = document.getElementById('discountBaseColour');
+    if (inp && ThemeManager && inp.value) {
+        ThemeManager.setDiscountColor(inp.value);
+    }
 }
 
 function openPostPackagingSettings() {

--- a/app/js/discountAnalysis.js
+++ b/app/js/discountAnalysis.js
@@ -54,12 +54,18 @@ const DiscountAnalysis = (function() {
                 tabs.forEach(t => t.classList.remove('active'));
                 btn.classList.add('active');
                 currentMarketplaceId = btn.dataset.id || '';
+                if (window.ThemeManager) {
+                    ThemeManager.applyThemeFor(currentMarketplaceId);
+                }
                 renderTable();
                 filterRows();
             });
         });
         tabs[0].classList.add('active');
         currentMarketplaceId = tabs[0].dataset.id || '';
+        if (window.ThemeManager) {
+            ThemeManager.applyThemeFor(currentMarketplaceId);
+        }
         renderTable();
         filterRows();
     }

--- a/app/js/productManager.js
+++ b/app/js/productManager.js
@@ -1480,6 +1480,10 @@ const ProductManager = (function() {
             return products.slice();
         },
 
+        getMarketplaces: function() {
+            return marketplaces.slice();
+        },
+
         isEditingProduct: function() {
             return isEditing;
         },

--- a/app/js/themeManager.js
+++ b/app/js/themeManager.js
@@ -1,0 +1,70 @@
+const ThemeManager = (function() {
+    let discountBaseColor = '#ff4d4d';
+
+    function loadTheme() {
+        const data = localStorage.getItem('nyoki_discount_theme');
+        if (data) {
+            try {
+                const obj = JSON.parse(data);
+                if (obj && obj.baseColor) {
+                    discountBaseColor = obj.baseColor;
+                }
+            } catch (e) {
+                discountBaseColor = '#ff4d4d';
+            }
+        }
+    }
+
+    function saveTheme() {
+        localStorage.setItem('nyoki_discount_theme', JSON.stringify({ baseColor: discountBaseColor }));
+    }
+
+    function lighten(hex, percent) {
+        const num = parseInt(hex.replace('#', ''), 16);
+        const r = (num >> 16) & 0xff;
+        const g = (num >> 8) & 0xff;
+        const b = num & 0xff;
+        const newR = Math.round(r + (255 - r) * (percent / 100));
+        const newG = Math.round(g + (255 - g) * (percent / 100));
+        const newB = Math.round(b + (255 - b) * (percent / 100));
+        return '#' + ((1 << 24) + (newR << 16) + (newG << 8) + newB).toString(16).slice(1);
+    }
+
+    function applyTheme() {
+        const colors = [80, 60, 40, 20, 0].map(p => lighten(discountBaseColor, p));
+        let styleEl = document.getElementById('discountThemeStyles');
+        if (!styleEl) {
+            styleEl = document.createElement('style');
+            styleEl.id = 'discountThemeStyles';
+            document.head.appendChild(styleEl);
+        }
+        styleEl.innerHTML =
+            `.disc10 { background-color: ${colors[0]}; }` +
+            `.disc20 { background-color: ${colors[1]}; }` +
+            `.disc30 { background-color: ${colors[2]}; }` +
+            `.disc40 { background-color: ${colors[3]}; }` +
+            `.disc50 { background-color: ${colors[4]}; }`;
+    }
+
+    return {
+        init: function() {
+            loadTheme();
+            applyTheme();
+        },
+        setDiscountColor: function(color) {
+            if (!/^#([0-9A-F]{3}){1,2}$/i.test(color)) {
+                Popup.alert('Please select a valid color');
+                return;
+            }
+            discountBaseColor = color;
+            saveTheme();
+            applyTheme();
+        },
+        getDiscountColor: function() {
+            return discountBaseColor;
+        }
+    };
+})();
+
+window.ThemeManager = ThemeManager;
+document.addEventListener('DOMContentLoaded', ThemeManager.init);

--- a/app/js/themeManager.js
+++ b/app/js/themeManager.js
@@ -1,22 +1,22 @@
 const ThemeManager = (function() {
-    let discountBaseColor = '#ff4d4d';
+    let themeData = { base: '#ff4d4d', mp: {} };
 
     function loadTheme() {
         const data = localStorage.getItem('nyoki_discount_theme');
         if (data) {
             try {
                 const obj = JSON.parse(data);
-                if (obj && obj.baseColor) {
-                    discountBaseColor = obj.baseColor;
+                if (obj && obj.base) {
+                    themeData = obj;
                 }
             } catch (e) {
-                discountBaseColor = '#ff4d4d';
+                themeData = { base: '#ff4d4d', mp: {} };
             }
         }
     }
 
     function saveTheme() {
-        localStorage.setItem('nyoki_discount_theme', JSON.stringify({ baseColor: discountBaseColor }));
+        localStorage.setItem('nyoki_discount_theme', JSON.stringify(themeData));
     }
 
     function lighten(hex, percent) {
@@ -30,8 +30,9 @@ const ThemeManager = (function() {
         return '#' + ((1 << 24) + (newR << 16) + (newG << 8) + newB).toString(16).slice(1);
     }
 
-    function applyTheme() {
-        const colors = [80, 60, 40, 20, 0].map(p => lighten(discountBaseColor, p));
+    function applyTheme(mpId = '') {
+        const base = themeData.mp[mpId] || themeData.base;
+        const colors = [80, 60, 40, 20, 0].map(p => lighten(base, p));
         let styleEl = document.getElementById('discountThemeStyles');
         if (!styleEl) {
             styleEl = document.createElement('style');
@@ -51,17 +52,24 @@ const ThemeManager = (function() {
             loadTheme();
             applyTheme();
         },
-        setDiscountColor: function(color) {
+        setDiscountColor: function(color, mpId = '') {
             if (!/^#([0-9A-F]{3}){1,2}$/i.test(color)) {
                 Popup.alert('Please select a valid color');
                 return;
             }
-            discountBaseColor = color;
+            if (mpId) {
+                themeData.mp[mpId] = color;
+            } else {
+                themeData.base = color;
+            }
             saveTheme();
-            applyTheme();
+            applyTheme(mpId);
         },
-        getDiscountColor: function() {
-            return discountBaseColor;
+        getDiscountColor: function(mpId = '') {
+            return themeData.mp[mpId] || themeData.base;
+        },
+        applyThemeFor: function(mpId = '') {
+            applyTheme(mpId);
         }
     };
 })();


### PR DESCRIPTION
## Summary
- allow color theme to be set for Discount Analysis
- persist selected base color in local storage
- apply saved color theme to `.discXX` table cells

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d30e100ac832fbdd7b2459e6d2cad